### PR TITLE
Make the Color Field Buttons use `background-color`

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ let restore_array = [];
 let index = -1;
 
 function change_color(e) {
-  draw_color = e.style.background;
+  draw_color = e.style["background-color"];
 }
 
 canvas.addEventListener("touchstart", start, false);


### PR DESCRIPTION
### Overview:
Noticed the Color Buttons weren't working so threw a log in **change_color** function and saw that `e.style.background` contains multiple background properties. This change just switches to target the `background-color` specifically.

### Changes:
- [x] switching to using the `background-color` in the **change_color** function 