### PR TITLE
Dispatch MouseEvents from TouchEvents

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,13 +27,54 @@ function aiDraw(e) {
   canvas.addEventListener("click").getElementById("draw");
 }
 
-// touch events not working
-canvas.addEventListener("touchstart", start, true);
-canvas.addEventListener("touchmove", draw, true);
-canvas.addEventListener("touchend", stop, false);
+// touch events
+canvas.addEventListener(
+  "touchstart",
+  function (e) {
+    var touch = e.touches[0];
+    var mouseEvent = new MouseEvent("mousedown", {
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+    });
+    canvas.dispatchEvent(mouseEvent);
+  },
+  false
+);
+canvas.addEventListener(
+  "touchmove",
+  function (e) {
+    var touch = e.touches[0];
+    var mouseEvent = new MouseEvent("mousemove", {
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+    });
+    canvas.dispatchEvent(mouseEvent);
+  },
+  false
+);
+canvas.addEventListener(
+  "touchend",
+  function (e) {
+    var mouseEvent = new MouseEvent("mouseup", {});
+    canvas.dispatchEvent(mouseEvent);
+  },
+  false
+);
+
+// mouse events
 canvas.addEventListener("mousedown", start, false);
 canvas.addEventListener("mousemove", draw, false);
 canvas.addEventListener("mouseup", stop, false);
+
+document.body.addEventListener("touchstart", handleTarget, false);
+document.body.addEventListener("touchmove", handleTarget, false);
+document.body.addEventListener("touchend", handleTarget, false);
+
+function handleTarget(e) {
+  if (e.target == canvas) {
+    e.preventDefault();
+  }
+}
 
 function start(e) {
   is_drawing = true;


### PR DESCRIPTION
### Overview:
This change modifies the event listeners of the touch events to create mouse events. The mouse events are then dispatched so the appropriate mouse event listeners can handle them. This effectively delegates the touch events to the mouse events.

### Changes:
- [x] change touch event listeners to create and dispatch mouse events
- [x] added event listeners on the `document.body` to check the target on touch events 
